### PR TITLE
Add convenience constructors for particle statefuls

### DIFF
--- a/src/phase_spaces/create.jl
+++ b/src/phase_spaces/create.jl
@@ -1,5 +1,22 @@
-# PSP constructors from particle statefuls
+"""
+    ParticleStateful{DIR, SPECIES}(mom::AbstractFourMomentum)
+    ParticleStateful{DIR, SPECIES, EL}(mom::EL)
 
+Construct a [`ParticleStateful`](@ref) from the given momentum on a fully or partially specified type.
+"""
+@inline function ParticleStateful{DIR,SPECIES}(
+    mom::AbstractFourMomentum
+) where {DIR<:ParticleDirection,SPECIES<:AbstractParticleType}
+    return ParticleStateful(DIR(), SPECIES(), mom)
+end
+
+@inline function ParticleStateful{DIR,SPECIES,EL}(
+    mom::EL
+) where {DIR<:ParticleDirection,SPECIES<:AbstractParticleType,EL<:AbstractFourMomentum}
+    return ParticleStateful(DIR(), SPECIES(), mom)
+end
+
+# PSP constructors from particle statefuls
 """
     InPhaseSpacePoint(
         proc::AbstractProcessDefinition, 

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -23,6 +23,9 @@ end
         mom = rand(RNG, SFourMomentum)
 
         particle_stateful = ParticleStateful(dir, species, mom)
+        @test particle_stateful == ParticleStateful{typeof(dir),typeof(species)}(mom)
+        @test particle_stateful ==
+            ParticleStateful{typeof(dir),typeof(species),typeof(mom)}(mom)
 
         # particle interface
         @test is_fermion(particle_stateful) == is_fermion(species)


### PR DESCRIPTION
This PR adds convenience constructors which are helpful when juggling the types around and wanting to construct a `ParticleStateful` from them. If `T` is a fully specialized `ParticleStateful{DIR, SPECIES, ELTYPE}`, before you would have had to extract the `DIR` and `SPECIES` to call the constructor, now you can simply do `T(mom)`.