### PR TITLE
[HOTFIX] fixed dependencies and compats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,26 +1,40 @@
 name = "QEDcore"
 uuid = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Anton Reinhard <a.reinhard@hzdr.de>"]
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Anton Reinhard <a.reinhard@hzdr.de>",
+]
 version = "0.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+DocStringExtensions = "^0.9"
+QEDbase = "0.2.2"
+Reexport = "^1.2"
+SimpleTraits = "^0.9"
+StaticArrays = "^1.9"
 julia = "1.6"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "SafeTestsets", "Test", "Suppressor"]
+test = [
+    "Random",
+    "LinearAlgebra",
+    "SafeTestsets",
+    "Test",
+    "Suppressor",
+    "SparseArrays",
+]


### PR DESCRIPTION
This fixes dependencies and compats on main:

* moves `SparseArrays` and `LinearAlgebra` to `[extras]`
* removed `SafeTestSets` from dependencies
* added compact for all strong deps (see https://github.com/JuliaRegistries/General/pull/111026#issuecomment-2227108811 for details)


Final remark: 
* after merging, this needs to be added to dev *after* #38 is merged
* **You shall not squash**