### PR TITLE
Hide the mul function

### DIFF
--- a/src/algebraic_objects/dirac_tensors/multiplication.jl
+++ b/src/algebraic_objects/dirac_tensors/multiplication.jl
@@ -16,10 +16,10 @@ Tensor product of an adjoint with a standard bi-spinor resulting in a scalar.
     This also overloads the `*` operator for this types.
 
 """
-function mul(aBS::AdjointBiSpinor, BS::BiSpinor)::ComplexF64
+function _mul(aBS::AdjointBiSpinor, BS::BiSpinor)::ComplexF64
     return aBS.el1 * BS.el1 + aBS.el2 * BS.el2 + aBS.el3 * BS.el3 + aBS.el4 * BS.el4
 end
-@inline *(aBS::AdjointBiSpinor, BS::BiSpinor) = mul(aBS::AdjointBiSpinor, BS::BiSpinor)
+@inline *(aBS::AdjointBiSpinor, BS::BiSpinor) = _mul(aBS::AdjointBiSpinor, BS::BiSpinor)
 
 """
 $(TYPEDSIGNATURES)
@@ -30,10 +30,10 @@ Tensor product of a standard with an adjoint bi-spinor resulting in a Dirac matr
     This also overloads the `*` operator for this types.
 
 """
-function mul(BS::BiSpinor, aBS::AdjointBiSpinor)::DiracMatrix
+function _mul(BS::BiSpinor, aBS::AdjointBiSpinor)::DiracMatrix
     return DiracMatrix(BS * transpose(aBS))
 end
-@inline *(BS::BiSpinor, aBS::AdjointBiSpinor) = mul(BS::BiSpinor, aBS::AdjointBiSpinor)
+@inline *(BS::BiSpinor, aBS::AdjointBiSpinor) = _mul(BS::BiSpinor, aBS::AdjointBiSpinor)
 
 """
 $(TYPEDSIGNATURES)
@@ -44,7 +44,7 @@ Tensor product of an Dirac matrix with a standard bi-spinor resulting in another
     This also overloads the `*` operator for this types.
 
 """
-function mul(DM::DiracMatrix, BS::BiSpinor)::BiSpinor
+function _mul(DM::DiracMatrix, BS::BiSpinor)::BiSpinor
     return DM * BS
 end
 
@@ -57,10 +57,10 @@ Tensor product of an adjoint bi-spinor with a Dirac matrix resulting in another 
     This also overloads the `*` operator for this types.
 
 """
-function mul(aBS::AdjointBiSpinor, DM::DiracMatrix)::AdjointBiSpinor
+function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix)::AdjointBiSpinor
     return transpose(aBS) * DM
 end
-@inline *(aBS::AdjointBiSpinor, DM::DiracMatrix) = mul(aBS, DM)
+@inline *(aBS::AdjointBiSpinor, DM::DiracMatrix) = _mul(aBS, DM)
 
 """
 $(TYPEDSIGNATURES)
@@ -71,7 +71,7 @@ Tensor product two Dirac matrices resulting in another Dirac matrix.
     This also overloads the `*` operator for this types.
 
 """
-function mul(DM1::DiracMatrix, DM2::DiracMatrix)::DiracMatrix
+function _mul(DM1::DiracMatrix, DM2::DiracMatrix)::DiracMatrix
     return DM1 * DM2
 end
 
@@ -80,6 +80,6 @@ $(TYPEDSIGNATURES)
 
 Tensor product of Dirac matrix sandwiched between an adjoint and a standard bi-spinor resulting in a scalar.
 """
-function mul(aBS::AdjointBiSpinor, DM::DiracMatrix, BS::BiSpinor)::ComplexF64
+function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix, BS::BiSpinor)::ComplexF64
     return transpose(aBS) * DM * BS
 end


### PR DESCRIPTION
Rename the mul function to _mul since it is not exported.
Goes together with https://github.com/QEDjl-project/QEDbase.jl/pull/110