### PR TITLE
Fix CI docs building

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Documentation
 on:
   push:
     branches:
-      - master
+      - main
       - dev
     tags: "*"
   pull_request:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,4 +24,4 @@ makedocs(;
     pages=["Home" => "index.md"],
 )
 
-deploydocs(; repo="github.com/QEDjl-project/QEDcore.jl", devbranch="main")
+deploydocs(; repo="github.com/QEDjl-project/QEDcore.jl", push_preview=false)


### PR DESCRIPTION
Fixes CI branch names and `deploydocs` call.
Apparently, the main branch did not ever deploy its documentation until now and the dev branch didn't update anymore...