### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Documentation
 on:
   push:
     branches:
-      - master
+      - main
       - dev
     tags: "*"
   pull_request:

--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -1,0 +1,33 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+    tags: "*"
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.10"
+      - name: Install dependencies
+        run: |
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: set dependencies to dev branch version
+        if: (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && github.base_ref != 'main')
+        run: |
+          git clone -b dev https://github.com/QEDjl-project/QED.jl.git /tmp/integration_test_tools
+          julia --project=docs/ /tmp/integration_test_tools/.ci/set_dev_dependencies.jl
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+        run: julia --project=docs/ docs/make.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 0.1.1
+
+This release contains some minor fixes and CI work. No breaking changes have been introduced.
+
+[diff since 0.1.0](https://github.com/QEDjl-project/QEDcore.jl/compare/release-0.1.0...release-0.1.1)
+
+### Fixes
+
+- [#42](https://github.com/QEDjl-project/QEDcore.jl/pull/42): Make `mul` function private since `*` should be used instead
+- [#47](https://github.com/QEDjl-project/QEDcore.jl/pull/47): Fix docs building to deploy to gh-pages correctly
+
+### Maintenance
+
+- [#44](https://github.com/QEDjl-project/QEDcore.jl/pull/44): Add docs building job to the CI 
+- [#46](https://github.com/QEDjl-project/QEDcore.jl/pull/46): Remove `Suppressor.jl` dependency which is not needed anymore
+
 ## Version 0.1.0
 
 **Initial Release**

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
@@ -35,6 +34,5 @@ test = [
     "LinearAlgebra",
     "SafeTestsets",
     "Test",
-    "Suppressor",
     "SparseArrays",
 ]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = [
     "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
     "Anton Reinhard <a.reinhard@hzdr.de>",
 ]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,4 +24,4 @@ makedocs(;
     pages=["Home" => "index.md"],
 )
 
-deploydocs(; repo="github.com/QEDjl-project/QEDcore.jl", devbranch="main")
+deploydocs(; repo="github.com/QEDjl-project/QEDcore.jl", push_preview=false)

--- a/src/algebraic_objects/dirac_tensors/multiplication.jl
+++ b/src/algebraic_objects/dirac_tensors/multiplication.jl
@@ -16,10 +16,10 @@ Tensor product of an adjoint with a standard bi-spinor resulting in a scalar.
     This also overloads the `*` operator for this types.
 
 """
-function mul(aBS::AdjointBiSpinor, BS::BiSpinor)::ComplexF64
+function _mul(aBS::AdjointBiSpinor, BS::BiSpinor)::ComplexF64
     return aBS.el1 * BS.el1 + aBS.el2 * BS.el2 + aBS.el3 * BS.el3 + aBS.el4 * BS.el4
 end
-@inline *(aBS::AdjointBiSpinor, BS::BiSpinor) = mul(aBS::AdjointBiSpinor, BS::BiSpinor)
+@inline *(aBS::AdjointBiSpinor, BS::BiSpinor) = _mul(aBS::AdjointBiSpinor, BS::BiSpinor)
 
 """
 $(TYPEDSIGNATURES)
@@ -30,10 +30,10 @@ Tensor product of a standard with an adjoint bi-spinor resulting in a Dirac matr
     This also overloads the `*` operator for this types.
 
 """
-function mul(BS::BiSpinor, aBS::AdjointBiSpinor)::DiracMatrix
+function _mul(BS::BiSpinor, aBS::AdjointBiSpinor)::DiracMatrix
     return DiracMatrix(BS * transpose(aBS))
 end
-@inline *(BS::BiSpinor, aBS::AdjointBiSpinor) = mul(BS::BiSpinor, aBS::AdjointBiSpinor)
+@inline *(BS::BiSpinor, aBS::AdjointBiSpinor) = _mul(BS::BiSpinor, aBS::AdjointBiSpinor)
 
 """
 $(TYPEDSIGNATURES)
@@ -44,7 +44,7 @@ Tensor product of an Dirac matrix with a standard bi-spinor resulting in another
     This also overloads the `*` operator for this types.
 
 """
-function mul(DM::DiracMatrix, BS::BiSpinor)::BiSpinor
+function _mul(DM::DiracMatrix, BS::BiSpinor)::BiSpinor
     return DM * BS
 end
 
@@ -57,10 +57,10 @@ Tensor product of an adjoint bi-spinor with a Dirac matrix resulting in another 
     This also overloads the `*` operator for this types.
 
 """
-function mul(aBS::AdjointBiSpinor, DM::DiracMatrix)::AdjointBiSpinor
+function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix)::AdjointBiSpinor
     return transpose(aBS) * DM
 end
-@inline *(aBS::AdjointBiSpinor, DM::DiracMatrix) = mul(aBS, DM)
+@inline *(aBS::AdjointBiSpinor, DM::DiracMatrix) = _mul(aBS, DM)
 
 """
 $(TYPEDSIGNATURES)
@@ -71,7 +71,7 @@ Tensor product two Dirac matrices resulting in another Dirac matrix.
     This also overloads the `*` operator for this types.
 
 """
-function mul(DM1::DiracMatrix, DM2::DiracMatrix)::DiracMatrix
+function _mul(DM1::DiracMatrix, DM2::DiracMatrix)::DiracMatrix
     return DM1 * DM2
 end
 
@@ -80,6 +80,6 @@ $(TYPEDSIGNATURES)
 
 Tensor product of Dirac matrix sandwiched between an adjoint and a standard bi-spinor resulting in a scalar.
 """
-function mul(aBS::AdjointBiSpinor, DM::DiracMatrix, BS::BiSpinor)::ComplexF64
+function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix, BS::BiSpinor)::ComplexF64
     return transpose(aBS) * DM * BS
 end


### PR DESCRIPTION
Release version 0.1.1 to main

This PR is opened from my fork. After discussion with @SimeonEhrig we have decided that we shouldn't need to keep the `release-*` branches since we have the tags to keep track of the previous versions. Since branches from this origin repository lead to race conditions in the gitlab mirroring, we should never push branches to this repository. The commits and common base of the dev and main branches are still preserved as long as we don't squash the release PRs.