### PR TITLE
Fix ParticleStatful builder for AMDGPU

### DIFF
--- a/src/phase_spaces/utility.jl
+++ b/src/phase_spaces/utility.jl
@@ -123,8 +123,21 @@ end
 
 @inline _momentum_type(::T) where {T<:PhaseSpacePoint} = _momentum_type(T)
 
+# these helpers should not be necessary, but currently are to support AMDGPU compilation
+@inline _build_ps_helper(dir::ParticleDirection, particles::Tuple{}, moms::Tuple{}) = ()
+@inline function _build_ps_helper(
+    dir::ParticleDirection,
+    particles::Tuple{P,Vararg},
+    moms::Tuple{AbstractFourMomentum,Vararg},
+) where {P}
+    return (
+        ParticleStateful(dir, particles[1], moms[1]),
+        _build_ps_helper(dir, particles[2:end], moms[2:end])...,
+    )
+end
+
 # convenience function building a type stable tuple of ParticleStatefuls from the given process, momenta, and direction
-function _build_particle_statefuls(
+@inline function _build_particle_statefuls(
     proc::AbstractProcessDefinition, moms::NTuple{N,ELEMENT}, dir::ParticleDirection
 ) where {N,ELEMENT<:AbstractFourMomentum}
     N == number_particles(proc, dir) || throw(
@@ -132,9 +145,8 @@ function _build_particle_statefuls(
             "expected $(number_particles(proc, dir)) $(dir) particles for the process but got $(N)",
         ),
     )
-    res = Tuple{_assemble_tuple_type(particles(proc, dir), dir, ELEMENT)...}(
-        ParticleStateful(dir, particle, mom) for
-        (particle, mom) in zip(particles(proc, dir), moms)
+    res::Tuple{_assemble_tuple_type(particles(proc, dir), dir, ELEMENT)...} = _build_ps_helper(
+        dir, particles(proc, dir), moms
     )
 
     return res


### PR DESCRIPTION
Add tuple unrolling helper function for AMDGPU. For some reason, it can't avoid dynamic function calls without this. It seems it's a good idea not to trust the compiler too much after all.