### PR TITLE
Fix flat phase space layout

### DIFF
--- a/src/phase_space_layouts/out_channel/flat_phase_space.jl
+++ b/src/phase_space_layouts/out_channel/flat_phase_space.jl
@@ -239,7 +239,9 @@ function _scale_single_rambo_mom(xi, mass, massless_mom)
 end
 
 function _scale_rambo_moms(xi, masses, massless_moms)
-    return Tuple(map(x -> _scale_single_rambo_mom(xi, x...), zip(masses, massless_moms)))
+    n = size(masses, 1)
+    return ntuple(i -> _scale_single_rambo_mom(xi, masses[i], massless_moms[i]), n)
+    #return Tuple(map(x -> _scale_single_rambo_mom(xi, x...), zip(masses, massless_moms)))
 end
 
 # Kleiss 1985: 2.14

--- a/src/phase_space_layouts/out_channel/flat_phase_space.jl
+++ b/src/phase_space_layouts/out_channel/flat_phase_space.jl
@@ -239,7 +239,7 @@ function _scale_single_rambo_mom(xi, mass, massless_mom)
 end
 
 function _scale_rambo_moms(xi, masses, massless_moms)
-    return map(x -> _scale_single_rambo_mom(xi, x...), zip(masses, massless_moms))
+    return Tuple(map(x -> _scale_single_rambo_mom(xi, x...), zip(masses, massless_moms)))
 end
 
 # Kleiss 1985: 2.14

--- a/test/phase_space_layouts/out_channel/flat_phase_space.jl
+++ b/test/phase_space_layouts/out_channel/flat_phase_space.jl
@@ -45,6 +45,7 @@ SUM_IN_MASSES = sum(IN_MASSES)
         @test length(test_out_moms) == N_OUTGOING
         @test isapprox(getMass.(test_out_moms), [OUT_MASSES...], atol=ATOL, rtol=RTOL)
         @test isapprox(sum(test_out_moms), sum(TESTINMOMS), atol=ATOL, rtol=RTOL)
+        @test test_out_moms isa Tuple
     end
 end
 

--- a/test/phase_space_layouts/out_channel/flat_phase_space.jl
+++ b/test/phase_space_layouts/out_channel/flat_phase_space.jl
@@ -43,7 +43,7 @@ SUM_IN_MASSES = sum(IN_MASSES)
         )
 
         @test length(test_out_moms) == N_OUTGOING
-        @test isapprox(getMass.(test_out_moms), [OUT_MASSES...], atol=ATOL, rtol=RTOL)
+        @test all(isapprox.(getMass.(test_out_moms), OUT_MASSES, atol=ATOL, rtol=RTOL))
         @test isapprox(sum(test_out_moms), sum(TESTINMOMS), atol=ATOL, rtol=RTOL)
         @test test_out_moms isa Tuple
     end


### PR DESCRIPTION
The return type if `_build_momenta` was a vector, which triggers a bug downstream in the construction of PSPs. 
This PR fixes this bug. 