### PR TITLE
Add a type to all mass/charge function calls

### DIFF
--- a/src/algebraic_objects/four_momentum.jl
+++ b/src/algebraic_objects/four_momentum.jl
@@ -137,19 +137,19 @@ end
 @inline QEDbase.getY(p::MFourMomentum) = p.py
 @inline QEDbase.getZ(p::MFourMomentum) = p.pz
 
-function QEDbase.setT!(lv::MFourMomentum, value::Float64)
+function QEDbase.setT!(lv::MFourMomentum, value::Real)
     return lv.E = value
 end
 
-function QEDbase.setX!(lv::MFourMomentum, value::Float64)
+function QEDbase.setX!(lv::MFourMomentum, value::Real)
     return lv.px = value
 end
 
-function QEDbase.setY!(lv::MFourMomentum, value::Float64)
+function QEDbase.setY!(lv::MFourMomentum, value::Real)
     return lv.py = value
 end
 
-function QEDbase.setZ!(lv::MFourMomentum, value::Float64)
+function QEDbase.setZ!(lv::MFourMomentum, value::Real)
     return lv.pz = value
 end
 

--- a/src/particles/particle_types.jl
+++ b/src/particles/particle_types.jl
@@ -82,13 +82,13 @@ electron
     Besides being a subtype of [`Fermion`](@ref), objects of type `Electron` have
 
     ```julia
-    mass(::Electron) = 1.0
-    charge(::Electron) = -1.0
+    mass(::Type{T}, ::Electron) = one(T)
+    charge(::Type{T}, ::Electron) = -one(T)
     ```
 """
 struct Electron <: Fermion end
-QEDbase.mass(::Electron) = 1.0
-QEDbase.charge(::Electron) = -1.0
+QEDbase.mass(::Type{T}, ::Electron) where {T} = one(T)
+QEDbase.charge(::Type{T}, ::Electron) where {T} = -one(T)
 Base.show(io::IO, ::Electron) = print(io, "electron")
 
 """
@@ -105,13 +105,13 @@ positron
     Besides being a subtype of [`AntiFermion`](@ref), objects of type `Positron` have
 
     ```julia
-    mass(::Positron) = 1.0
-    charge(::Positron) = 1.0
+    mass(::Type{T}, ::Positron) = one(T)
+    charge(::Type{T}, ::Positron) = one(T)
     ```
 """
 struct Positron <: AntiFermion end
-QEDbase.mass(::Positron) = 1.0
-QEDbase.charge(::Positron) = 1.0
+QEDbase.mass(::Type{T}, ::Positron) where {T} = one(T)
+QEDbase.charge(::Type{T}, ::Positron) where {T} = one(T)
 Base.show(io::IO, ::Positron) = print(io, "positron")
 
 """
@@ -183,11 +183,11 @@ photon
     Besides being a subtype of `MajoranaBoson`, `Photon` has
 
     ```julia
-    mass(::Photon) = 0.0
-    charge(::Photon) = 0.0
+    mass(::Type{T}, ::Photon) = zero(T)
+    charge(::Type{T}, ::Photon) = zero(T)
     ```
 """
 struct Photon <: MajoranaBoson end
-QEDbase.mass(::Photon) = 0.0
-QEDbase.charge(::Photon) = 0.0
+QEDbase.mass(::Type{T}, ::Photon) where {T} = zero(T)
+QEDbase.charge(::Type{T}, ::Photon) where {T} = zero(T)
 Base.show(io::IO, ::Photon) = print(io, "photon")

--- a/src/particles/propagators.jl
+++ b/src/particles/propagators.jl
@@ -16,7 +16,7 @@ function _fermion_propagator(P::AbstractFourMomentum)
 end
 
 function QEDbase.propagator(particle_type::BosonLike, K::AbstractFourMomentum)
-    return _scalar_propagator(K, mass(particle_type))
+    return _scalar_propagator(K, mass(eltype(K), particle_type))
 end
 
 function QEDbase.propagator(particle_type::Photon, K::AbstractFourMomentum)
@@ -24,5 +24,5 @@ function QEDbase.propagator(particle_type::Photon, K::AbstractFourMomentum)
 end
 
 function QEDbase.propagator(particle_type::FermionLike, P::AbstractFourMomentum)
-    return _fermion_propagator(P, mass(particle_type))
+    return _fermion_propagator(P, mass(eltype(P), particle_type))
 end

--- a/src/particles/states.jl
+++ b/src/particles/states.jl
@@ -12,14 +12,14 @@ function QEDbase.base_state(
     particle::Fermion, ::Incoming, mom::AbstractFourMomentum{T}, spin::AbstractDefiniteSpin
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_fermion(mom, mass(particle))
+    booster = _booster_fermion(mom, mass(T, particle))
     return BiSpinor{T_COMPLEX}(@inbounds booster[:, QEDbase._spin_index(spin)])
 end
 
 function QEDbase.base_state(
     particle::Fermion, ::Incoming, mom::AbstractFourMomentum{T}, spin::AllSpin
 ) where {T<:Real}
-    booster = _booster_fermion(mom, mass(particle))
+    booster = _booster_fermion(mom, mass(T, particle))
     return SVector(BiSpinor(@inbounds booster[:, 1]), BiSpinor(@inbounds booster[:, 2]))
 end
 
@@ -30,7 +30,7 @@ function QEDbase.base_state(
     spin::AbstractDefiniteSpin,
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_antifermion(mom, mass(particle))
+    booster = _booster_antifermion(mom, mass(T, particle))
     return AdjointBiSpinor(BiSpinor(@inbounds booster[:, QEDbase._spin_index(spin) + 2])) *
            (@inbounds gamma(T_COMPLEX)[1])
 end
@@ -39,7 +39,7 @@ function QEDbase.base_state(
     particle::AntiFermion, ::Incoming, mom::AbstractFourMomentum{T}, spin::AllSpin
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_antifermion(mom, mass(particle))
+    booster = _booster_antifermion(mom, mass(T, particle))
     return SVector(
         AdjointBiSpinor(@inbounds BiSpinor(booster[:, 3])) *
         (@inbounds gamma(T_COMPLEX)[1]),
@@ -52,7 +52,7 @@ function QEDbase.base_state(
     particle::Fermion, ::Outgoing, mom::AbstractFourMomentum{T}, spin::AbstractDefiniteSpin
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_fermion(mom, mass(particle))
+    booster = _booster_fermion(mom, mass(T, particle))
     return AdjointBiSpinor(BiSpinor(@inbounds booster[:, QEDbase._spin_index(spin)])) *
            (@inbounds gamma(T_COMPLEX)[1])
 end
@@ -61,7 +61,7 @@ function QEDbase.base_state(
     particle::Fermion, ::Outgoing, mom::AbstractFourMomentum{T}, spin::AllSpin
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_fermion(mom, mass(particle))
+    booster = _booster_fermion(mom, mass(T, particle))
     return SVector(
         AdjointBiSpinor(BiSpinor(@inbounds booster[:, 1])) *
         (@inbounds gamma(T_COMPLEX)[1]),
@@ -77,7 +77,7 @@ function QEDbase.base_state(
     spin::AbstractDefiniteSpin,
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_antifermion(mom, mass(particle))
+    booster = _booster_antifermion(mom, mass(T, particle))
     return BiSpinor{T_COMPLEX}(@inbounds booster[:, QEDbase._spin_index(spin) + 2])
 end
 
@@ -85,7 +85,7 @@ function QEDbase.base_state(
     particle::AntiFermion, ::Outgoing, mom::AbstractFourMomentum{T}, spin::AllSpin
 ) where {T<:Real}
     T_COMPLEX = _complex_from_real_t(T)
-    booster = _booster_antifermion(mom, mass(particle))
+    booster = _booster_antifermion(mom, mass(T, particle))
     return SVector(
         BiSpinor{T_COMPLEX}(@inbounds booster[:, 3]),
         BiSpinor{T_COMPLEX}(@inbounds booster[:, 4]),

--- a/src/phase_space_layouts/in_channel/two_body/rest_system.jl
+++ b/src/phase_space_layouts/in_channel/two_body/rest_system.jl
@@ -141,15 +141,17 @@ function QEDbase._build_momenta(
     ::TwoBodyRestSystem{RESTIDX,<:Energy{RUNIDX}},
     in_coords,
 ) where {RESTIDX,RUNIDX}
-    masses = mass.(incoming_particles(proc))
+    T = eltype(in_coords)
+
+    masses = mass.(Ref(T), incoming_particles(proc))
     mass_rest = masses[RESTIDX]
-    P_rest = SFourMomentum(mass_rest, 0, 0, 0)
+    P_rest = SFourMomentum{T}(mass_rest, 0, 0, 0)
 
     mass_run = masses[RUNIDX]
     energy_run = @inbounds in_coords[1]
 
     rho_run = sqrt(energy_run^2 - mass_run^2)
-    P_run = SFourMomentum(energy_run, 0, 0, rho_run)
+    P_run = SFourMomentum{T}(energy_run, 0, 0, rho_run)
 
     return _order_moms(RESTIDX, RUNIDX, P_rest, P_run)
 end
@@ -160,15 +162,17 @@ function QEDbase._build_momenta(
     ::TwoBodyRestSystem{RESTIDX,<:SpatialMagnitude{RUNIDX}},
     in_coords,
 ) where {RESTIDX,RUNIDX}
-    masses = mass.(incoming_particles(proc))
+    T = eltype(in_coords)
+
+    masses = mass.(Ref(T), incoming_particles(proc))
     mass_rest = masses[RESTIDX]
-    P_rest = SFourMomentum(mass_rest, 0, 0, 0)
+    P_rest = SFourMomentum{T}(mass_rest, 0, 0, 0)
 
     mass_run = masses[RUNIDX]
     rho_run = @inbounds in_coords[1]
 
     energy_run = sqrt(rho_run^2 + mass_run^2)
-    P_run = SFourMomentum(energy_run, 0, 0, rho_run)
+    P_run = SFourMomentum{T}(energy_run, 0, 0, rho_run)
 
     return _order_moms(RESTIDX, RUNIDX, P_rest, P_run)
 end
@@ -179,11 +183,13 @@ function QEDbase._build_momenta(
     in_psl::TwoBodyRestSystem{RESTIDX,<:CMSEnergy},
     in_coords,
 ) where {RESTIDX}
+    T = eltype(in_coords)
+
     RUNIDX = _the_other(RESTIDX)
 
-    masses = mass.(incoming_particles(proc))
+    masses = mass.(Ref(T), incoming_particles(proc))
     mass_rest = @inbounds masses[RESTIDX]
-    P_rest = SFourMomentum(mass_rest, 0, 0, 0)
+    P_rest = SFourMomentum{T}(mass_rest, 0, 0, 0)
 
     mass_run = @inbounds masses[RUNIDX]
     sqrt_s_run = @inbounds in_coords[1]
@@ -191,7 +197,7 @@ function QEDbase._build_momenta(
     energy_run = (sqrt_s_run^2 - mass_run^2 - mass_rest^2) / (2 * mass_rest)
     rho_run = sqrt(energy_run^2 - mass_run^2)
 
-    P_run = SFourMomentum(energy_run, 0, 0, rho_run)
+    P_run = SFourMomentum{T}(energy_run, 0, 0, rho_run)
 
     return _order_moms(RESTIDX, RUNIDX, P_rest, P_run)
 end
@@ -202,15 +208,17 @@ function QEDbase._build_momenta(
     in_psl::TwoBodyRestSystem{RESTIDX,<:Rapidity{RUNIDX}},
     in_coords,
 ) where {RESTIDX,RUNIDX}
-    masses = mass.(incoming_particles(proc))
+    T = eltype(in_coords)
+
+    masses = mass.(Ref(T), incoming_particles(proc))
     mass_rest = @inbounds masses[RESTIDX]
-    P_rest = SFourMomentum(mass_rest, 0, 0, 0)
+    P_rest = SFourMomentum{T}(mass_rest, 0, 0, 0)
 
     mass_run = @inbounds masses[RUNIDX]
     rapidity_run = @inbounds in_coords[1]
     energy_run = mass_run * cosh(rapidity_run)
     rho_run = mass_run * sinh(rapidity_run)
-    P_run = SFourMomentum(energy_run, 0, 0, rho_run)
+    P_run = SFourMomentum{T}(energy_run, 0, 0, rho_run)
 
     return _order_moms(RESTIDX, RUNIDX, P_rest, P_run)
 end

--- a/test/particles/propagators.jl
+++ b/test/particles/propagators.jl
@@ -2,24 +2,27 @@ using Random
 using QEDcore
 
 RNG = MersenneTwister(137137)
-ATOL = 0.0
-RTOL = sqrt(eps())
 
-function _rand_momentum(rng::AbstractRNG)
-    return SFourMomentum(rand(rng, 4))
+function _rand_momentum(rng::AbstractRNG, ::Type{T}) where {T<:Number}
+    return SFourMomentum(rand(rng, T, 4))
 end
 
 groundtruth_propagator(::Photon, mom) = one(eltype(mom)) / (mom * mom)
 function groundtruth_propagator(particle::FermionLike, mom)
-    return (slashed(mom) + mass(particle) * one(DiracMatrix)) /
-           (mom * mom - mass(particle)^2)
+    return (slashed(mom) + mass(eltype(mom), particle) * one(DiracMatrix)) /
+           (mom * mom - mass(eltype(mom), particle)^2)
 end
 
-@testset "propagators" begin
+@testset "propagators with $FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
     @testset "$P" for P in (Electron(), Positron(), Photon())
-        mom = _rand_momentum(RNG)
+        mom = _rand_momentum(RNG, FLOAT_T)
         groundtruth = groundtruth_propagator(P, mom)
         test_prop = propagator(P, mom)
-        @test isapprox(test_prop, groundtruth, atol=ATOL, rtol=RTOL)
+        @test isapprox(test_prop, groundtruth, atol=zero(FLOAT_T), rtol=sqrt(eps(FLOAT_T)))
+        if P isa Photon
+            @test test_prop isa FLOAT_T
+        else
+            @test test_prop isa DiracMatrix{Complex{FLOAT_T}}
+        end
     end
 end

--- a/test/particles/states.jl
+++ b/test/particles/states.jl
@@ -5,8 +5,6 @@ using Random
 include("../utils.jl")
 
 RNG = MersenneTwister(708583836976)
-ATOL = 1e-14
-RTOL = 0.0
 PHOTON_ENERGIES = (0.0, rand(RNG), rand(RNG) * 10)
 COS_THETAS = (-1.0, -rand(RNG), 0.0, rand(RNG), 1.0)
 
@@ -48,15 +46,29 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
             @test QEDbase._as_svec(base_state(p(), d(), mom, SpinDown())) isa SVector
         end
     end
-    @testset "spinor properties" begin
-        x, y, z = rand(RNG, 3)
-        m = mass(Electron())
-        P = SFourMomentum(sqrt(x^2 + y^2 + z^2 + m^2), x, y, z)
+    @testset "spinor properties in $FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
+        RTOL = zero(FLOAT_T)
+        ATOL = if FLOAT_T == Float64
+            1e-14
+        elseif FLOAT_T == Float32
+            1e-6
+        elseif FLOAT_T == Float16
+            1e-2
+        end
+
+        x, y, z = rand(RNG, FLOAT_T, 3)
+        m = mass(FLOAT_T, Electron())
+        P = SFourMomentum{FLOAT_T}(sqrt(x^2 + y^2 + z^2 + m^2), x, y, z)
 
         U = base_state(Electron(), Incoming(), P, AllSpin())
         Ubar = base_state(Electron(), Outgoing(), P, AllSpin())
         V = base_state(Positron(), Outgoing(), P, AllSpin())
         Vbar = base_state(Positron(), Incoming(), P, AllSpin())
+
+        @test eltype(U) == BiSpinor{Complex{FLOAT_T}}
+        @test eltype(Ubar) == AdjointBiSpinor{Complex{FLOAT_T}}
+        @test eltype(V) == BiSpinor{Complex{FLOAT_T}}
+        @test eltype(Vbar) == AdjointBiSpinor{Complex{FLOAT_T}}
 
         @testset "normalization" begin
             for s1 in (1, 2)
@@ -70,33 +82,37 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
         end # normalization
 
         @testset "completeness" begin
-            sumU = zero(DiracMatrix)
-            sumV = zero(DiracMatrix)
+            sumU = zero(DiracMatrix{FLOAT_T})
+            sumV = zero(DiracMatrix{FLOAT_T})
             for spin in (1, 2)
                 sumU += U[spin] * Ubar[spin]
                 sumV += V[spin] * Vbar[spin]
             end
 
-            @test isapprox(sumU, (slashed(P) + m * one(DiracMatrix)))
-            @test isapprox(sumV, (slashed(P) - m * one(DiracMatrix)))
+            @test isapprox(sumU, (slashed(P) + m * one(DiracMatrix{FLOAT_T})))
+            @test isapprox(sumV, (slashed(P) - m * one(DiracMatrix{FLOAT_T})))
         end # completeness
 
         @testset "diracs equation" begin
             for spin in (1, 2)
                 @test isapprox(
-                    (slashed(P) - m * one(DiracMatrix)) * U[spin], zero(BiSpinor), atol=ATOL
-                )
-                @test isapprox(
-                    (slashed(P) + m * one(DiracMatrix)) * V[spin], zero(BiSpinor), atol=ATOL
-                )
-                @test isapprox(
-                    Ubar[spin] * (slashed(P) - m * one(DiracMatrix)),
-                    zero(AdjointBiSpinor),
+                    (slashed(P) - m * one(DiracMatrix{FLOAT_T})) * U[spin],
+                    zero(BiSpinor{FLOAT_T}),
                     atol=ATOL,
                 )
                 @test isapprox(
-                    Vbar[spin] * (slashed(P) + m * one(DiracMatrix)),
-                    zero(AdjointBiSpinor),
+                    (slashed(P) + m * one(DiracMatrix{FLOAT_T})) * V[spin],
+                    zero(BiSpinor{FLOAT_T}),
+                    atol=ATOL,
+                )
+                @test isapprox(
+                    Ubar[spin] * (slashed(P) - m * one(DiracMatrix{FLOAT_T})),
+                    zero(AdjointBiSpinor{FLOAT_T}),
+                    atol=ATOL,
+                )
+                @test isapprox(
+                    Vbar[spin] * (slashed(P) + m * one(DiracMatrix{FLOAT_T})),
+                    zero(AdjointBiSpinor{FLOAT_T}),
                     atol=ATOL,
                 )
             end
@@ -124,42 +140,64 @@ end
     @testset "$D" for D in [Incoming, Outgoing]
         @testset "$om $cth $phi" for (om, cth, phi) in
                                      Iterators.product(PHOTON_ENERGIES, COS_THETAS, PHIS)
-            #@testset "$x $y $z" for (x,y,z) in Iterators.product(X_arr,Y_arr,Z_arr)
+            @testset "$FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
+                RTOL = zero(FLOAT_T)
+                ATOL = if FLOAT_T == Float64
+                    1e-14
+                elseif FLOAT_T == Float32
+                    1e-6
+                elseif FLOAT_T == Float16
+                    1e-2
+                end
 
-            mom = SFourMomentum(_cartesian_coordinates(om, om, cth, phi))
-            both_photon_states = base_state(Photon(), D(), mom, AllPolarization())
+                mom = SFourMomentum{FLOAT_T}(_cartesian_coordinates(om, om, cth, phi))
+                both_photon_states = base_state(Photon(), D(), mom, AllPolarization())
 
-            # property test the photon states
-            @test isapprox((both_photon_states[1] * mom), 0.0, atol=ATOL, rtol=RTOL)
-            @test isapprox((both_photon_states[2] * mom), 0.0, atol=ATOL, rtol=RTOL)
-            @test isapprox(
-                (both_photon_states[1] * both_photon_states[1]), -1.0, atol=ATOL, rtol=RTOL
-            )
-            @test isapprox(
-                (both_photon_states[2] * both_photon_states[2]), -1.0, atol=ATOL, rtol=RTOL
-            )
-            @test isapprox(
-                (both_photon_states[1] * both_photon_states[2]), 0.0, atol=ATOL, rtol=RTOL
-            )
+                @test eltype(both_photon_states) == SLorentzVector{FLOAT_T}
 
-            # test the single polarization states
-            @test base_state(Photon(), D(), mom, PolarizationX()) == both_photon_states[1]
-            @test base_state(Photon(), D(), mom, PolarizationY()) == both_photon_states[2]
-            @test base_state(Photon(), D(), mom, PolX()) == both_photon_states[1]
-            @test base_state(Photon(), D(), mom, PolY()) == both_photon_states[2]
+                # property test the photon states
+                @test isapprox((both_photon_states[1] * mom), 0.0, atol=ATOL, rtol=RTOL)
+                @test isapprox((both_photon_states[2] * mom), 0.0, atol=ATOL, rtol=RTOL)
+                @test isapprox(
+                    (both_photon_states[1] * both_photon_states[1]),
+                    -one(FLOAT_T),
+                    atol=ATOL,
+                    rtol=RTOL,
+                )
+                @test isapprox(
+                    (both_photon_states[2] * both_photon_states[2]),
+                    -one(FLOAT_T),
+                    atol=ATOL,
+                    rtol=RTOL,
+                )
+                @test isapprox(
+                    (both_photon_states[1] * both_photon_states[2]),
+                    zero(FLOAT_T),
+                    atol=ATOL,
+                    rtol=RTOL,
+                )
 
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolX())) isa SVector
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolY())) isa SVector
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol())) isa SVector
+                # test the single polarization states
+                @test base_state(Photon(), D(), mom, PolarizationX()) ==
+                    both_photon_states[1]
+                @test base_state(Photon(), D(), mom, PolarizationY()) ==
+                    both_photon_states[2]
+                @test base_state(Photon(), D(), mom, PolX()) == both_photon_states[1]
+                @test base_state(Photon(), D(), mom, PolY()) == both_photon_states[2]
 
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolX()))[1] ==
-                both_photon_states[1]
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolY()))[1] ==
-                both_photon_states[2]
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol()))[1] ==
-                both_photon_states[1]
-            @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol()))[2] ==
-                both_photon_states[2]
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolX())) isa SVector
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolY())) isa SVector
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol())) isa SVector
+
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolX()))[1] ==
+                    both_photon_states[1]
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, PolY()))[1] ==
+                    both_photon_states[2]
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol()))[1] ==
+                    both_photon_states[1]
+                @test QEDbase._as_svec(base_state(Photon(), D(), mom, AllPol()))[2] ==
+                    both_photon_states[2]
+            end
         end
     end
 end

--- a/test/particles/states.jl
+++ b/test/particles/states.jl
@@ -8,6 +8,10 @@ RNG = MersenneTwister(708583836976)
 PHOTON_ENERGIES = (0.0, rand(RNG), rand(RNG) * 10)
 COS_THETAS = (-1.0, -rand(RNG), 0.0, rand(RNG), 1.0)
 
+rtol_atol(::Type{Float64}) = (zero(Float64), Float64(1e-14))
+rtol_atol(::Type{Float32}) = (zero(Float32), Float32(1e-6))
+rtol_atol(::Type{Float16}) = (zero(Float16), Float16(1e-2))
+
 # check every quadrant
 PHIS = (
     0.0,
@@ -47,14 +51,7 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
         end
     end
     @testset "spinor properties in $FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
-        RTOL = zero(FLOAT_T)
-        ATOL = if FLOAT_T == Float64
-            1e-14
-        elseif FLOAT_T == Float32
-            1e-6
-        elseif FLOAT_T == Float16
-            1e-2
-        end
+        (RTOL, ATOL) = rtol_atol(FLOAT_T)
 
         x, y, z = rand(RNG, FLOAT_T, 3)
         m = mass(FLOAT_T, Electron())
@@ -141,14 +138,7 @@ end
         @testset "$om $cth $phi" for (om, cth, phi) in
                                      Iterators.product(PHOTON_ENERGIES, COS_THETAS, PHIS)
             @testset "$FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
-                RTOL = zero(FLOAT_T)
-                ATOL = if FLOAT_T == Float64
-                    1e-14
-                elseif FLOAT_T == Float32
-                    1e-6
-                elseif FLOAT_T == Float16
-                    1e-2
-                end
+                (RTOL, ATOL) = rtol_atol(FLOAT_T)
 
                 mom = SFourMomentum{FLOAT_T}(_cartesian_coordinates(om, om, cth, phi))
                 both_photon_states = base_state(Photon(), D(), mom, AllPolarization())

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -33,8 +33,8 @@ end
         @test is_anti_particle(particle_stateful) == is_anti_particle(species)
         @test is_incoming(particle_stateful) == is_incoming(dir)
         @test is_outgoing(particle_stateful) == is_outgoing(dir)
-        @test mass(particle_stateful) == mass(species)
-        @test charge(particle_stateful) == charge(species)
+        @test mass(Float64, particle_stateful) == mass(Float64, species)
+        @test charge(Float64, particle_stateful) == charge(Float64, species)
 
         # accessors
         @test particle_stateful.dir == dir

--- a/test/test_implementation/test_particles.jl
+++ b/test/test_implementation/test_particles.jl
@@ -2,8 +2,8 @@
 # dummy particles
 struct TestParticle <: AbstractParticleType end # generic particle
 struct TestParticleFermion <: FermionLike end
-QEDbase.mass(::TestParticleFermion) = 1.2
+QEDbase.mass(::Type{T}, ::TestParticleFermion) where {T<:Number} = T(1.2)
 struct TestParticleBoson <: BosonLike end
-QEDbase.mass(::TestParticleBoson) = 2.3
+QEDbase.mass(::Type{T}, ::TestParticleBoson) where {T<:Number} = T(2.3)
 
 const PARTICLE_SET = [TestParticleFermion(), TestParticleBoson()]


### PR DESCRIPTION
See https://github.com/QEDjl-project/QEDbase.jl/pull/161

Pass the correct type to the mass function everywhere to not accidentally promote types.