### PR TITLE
Fix (adjoint) bi spinor multiplication

### DIFF
--- a/src/algebraic_objects/dirac_tensors/multiplication.jl
+++ b/src/algebraic_objects/dirac_tensors/multiplication.jl
@@ -11,7 +11,6 @@ Tensor product of an adjoint with a standard bi-spinor resulting in a scalar.
 
 !!! note "Multiplication operator"
     This also overloads the `*` operator for this types.
-
 """
 function _mul(aBS::AdjointBiSpinor, BS::BiSpinor)
     return aBS.el1 * BS.el1 + aBS.el2 * BS.el2 + aBS.el3 * BS.el3 + aBS.el4 * BS.el4
@@ -26,10 +25,9 @@ Tensor product of a standard with an adjoint bi-spinor resulting in a Dirac matr
 
 !!! note "Multiplication operator"
     This also overloads the `*` operator for this types.
-
 """
 function _mul(BS::BiSpinor, aBS::AdjointBiSpinor)::DiracMatrix
-    return DiracMatrix(BS * transpose(aBS))
+    return DiracMatrix(SVector(BS) * transpose(SVector(aBS)))
 end
 @inline Base.:*(BS::BiSpinor, aBS::AdjointBiSpinor) =
     _mul(BS::BiSpinor, aBS::AdjointBiSpinor)
@@ -41,7 +39,6 @@ Tensor product of an Dirac matrix with a standard bi-spinor resulting in another
 
 !!! note "Multiplication operator"
     This also overloads the `*` operator for this types.
-
 """
 function _mul(DM::DiracMatrix, BS::BiSpinor)::BiSpinor
     return BiSpinor(SMatrix(DM) * SVector(BS))
@@ -55,10 +52,9 @@ Tensor product of an adjoint bi-spinor with a Dirac matrix resulting in another 
 
 !!! note "Multiplication operator"
     This also overloads the `*` operator for this types.
-
 """
 function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix)::AdjointBiSpinor
-    return transpose(aBS) * DM
+    return AdjointBiSpinor(transpose(SVector(aBS)) * SMatrix(DM))
 end
 @inline Base.:*(aBS::AdjointBiSpinor, DM::DiracMatrix) = _mul(aBS, DM)
 
@@ -69,17 +65,48 @@ Tensor product two Dirac matrices resulting in another Dirac matrix.
 
 !!! note "Multiplication operator"
     This also overloads the `*` operator for this types.
-
 """
-function _mul(DM1::DiracMatrix, DM2::DiracMatrix)::DiracMatrix
-    return DM1 * DM2
+function _mul(dm1::DiracMatrix, dm2::DiracMatrix)::DiracMatrix
+    return DiracMatrix(SMatrix(dm1) * SMatrix(dm2))
 end
+@inline Base.:*(dm1::DiracMatrix, dm2::DiracMatrix)::DiracMatrix = _mul(dm1, dm2)
 
 """
 $(TYPEDSIGNATURES)
 
 Tensor product of Dirac matrix sandwiched between an adjoint and a standard bi-spinor resulting in a scalar.
 """
-function _mul(aBS::AdjointBiSpinor, DM::DiracMatrix, BS::BiSpinor)::ComplexF64
-    return transpose(aBS) * DM * BS
+function _mul(abs::AdjointBiSpinor, dm::DiracMatrix, bs::BiSpinor)
+    return transpose(SVector(abs)) * SMatrix(dm) * SVector(bs)
 end
+@inline Base.:*(abs::AdjointBiSpinor, dm::DiracMatrix, bs::BiSpinor) = _mul(abs, dm, bs)
+
+"""
+$(TYPEDSIGNATURES)
+
+The product of a Dirac matrix with an adjoint bi-spinor from the right is not defined.
+Therefore, this throws a method error.
+
+!!! note
+    We must throw this error explicitly, because otherwise the multiplication is
+    dispatched to methods from StaticArrays.jl.
+"""
+function _mul(d::DiracMatrix, a::AdjointBiSpinor)
+    throw(MethodError(*, (d, a)))
+end
+@inline Base.:*(d::DiracMatrix, a::AdjointBiSpinor) = _mul(d, a)
+
+"""
+$(TYPEDSIGNATURES)
+
+The product of a Dirac matrix with a bi-spinor from the left is not defined.
+Therefore, this throws a method error.
+
+!!! note
+    We must throw this error explicitly, because otherwise the multiplication is
+    dispatched to methods from StaticArrays.jl.
+"""
+function _mul(b::BiSpinor, d::DiracMatrix)
+    throw(MethodError(*, (b, d)))
+end
+@inline Base.:*(b::BiSpinor, d::DiracMatrix) = _mul(b, d)

--- a/test/algebraic_objects/lorentz_vector.jl
+++ b/test/algebraic_objects/lorentz_vector.jl
@@ -76,6 +76,9 @@ unary_methods = [-, +]
         @test @inferred(LV_mat * BS) == LV_BS
         @test @inferred(aBS * LV_mat) == LV_aBS
         @test @inferred(LV_aBS * LV_BS) == -60.0 + 0.0im
+
+        @test_throws MethodError LV_mat * aBS
+        @test_throws MethodError BS * LV_mat
     end #interface dirac tensor
 
     @testset "utility functions" begin


### PR DESCRIPTION
This adds explicit throwing overloads for bi-spinor * Dirac matrix and Dirac matrix * adjoint bi-spinor.
I also fixed that some tests did not actually run for the tensor products, and method errors are checked there now.

Fixes #68 