### PR TITLE
Remove printing inlines to enable color printing

### DIFF
--- a/src/phase_spaces/print.jl
+++ b/src/phase_spaces/print.jl
@@ -1,31 +1,31 @@
 function Base.show(io::IO, particle::ParticleStateful)
-    print(io, "$(particle.dir) $(particle.species): $(particle.mom)")
+    print(io, particle.dir, " ", particle.species, ": ", particle.mom)
     return nothing
 end
 
 function Base.show(io::IO, m::MIME"text/plain", particle::ParticleStateful)
-    println(io, "ParticleStateful: $(particle.dir) $(particle.species)")
-    println(io, "    momentum: $(particle.mom)")
+    println(io, "ParticleStateful: ", particle.dir, " ", particle.species)
+    println(io, "    momentum: ", particle.mom)
     return nothing
 end
 
 function Base.show(io::IO, psp::PhaseSpacePoint)
-    print(io, "PhaseSpacePoint of $(psp.proc)")
+    print(io, "PhaseSpacePoint of ", psp.proc)
     return nothing
 end
 
-function Base.show(io::IO, ::MIME"text/plain", psp::PhaseSpacePoint)
+function Base.show(io::IO, m::MIME"text/plain", psp::PhaseSpacePoint)
     println(io, "PhaseSpacePoint:")
-    println(io, "    process: $(psp.proc)")
-    println(io, "    model: $(psp.model)")
-    println(io, "    phase space layout: $(psp.psl)")
+    println(io, "    process: ", psp.proc)
+    println(io, "    model: ", psp.model)
+    println(io, "    phase space layout: ", psp.psl)
     println(io, "    incoming particles:")
     for p in psp.in_particles
-        println(io, "     -> $(p)")
+        println(io, "     -> ", p)
     end
     println(io, "    outgoing particles:")
     for p in psp.out_particles
-        println(io, "     -> $(p)")
+        println(io, "     -> ", p)
     end
     return nothing
 end


### PR DESCRIPTION
Unfortunately, the `"$variable"` syntax prevents printing in color, so I removed it and used the variadic version of print instead. Now, if the fields of a phase space point or particle stateful want to print in color or bold/italic/underlined, they can.