### PR TITLE
Add type aware constants

### DIFF
--- a/docs/Bibliography.bib
+++ b/docs/Bibliography.bib
@@ -8,3 +8,17 @@
     pages = "359",
     year = "1986"
 }
+
+@article{CODATA2022,
+    author = "Mohr, Peter J. and Newell, David B. and Taylor, Barry N. and Tiesinga, Eite",
+    title = "{CODATA recommended values of the fundamental physical constants: 2022*}",
+    eprint = "2409.03787",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1103/RevModPhys.97.025002",
+    journal = "Rev. Mod. Phys.",
+    volume = "97",
+    number = "2",
+    pages = "025002",
+    year = "2025"
+}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,6 +45,7 @@ end
 literate_paths = [
     Base.Filesystem.joinpath(project_path, "docs/src/tutorial/particles.jl"),
     Base.Filesystem.joinpath(project_path, "docs/src/tutorial/vectors.jl"),
+    Base.Filesystem.joinpath(project_path, "docs/src/tutorial/constants.jl"),
 ]
 
 tutorial_output_dir = joinpath(project_path, "docs/src/generated/")
@@ -59,10 +60,12 @@ pages = [
         "Particles and Phase Space Points" =>
             joinpath(tutorial_output_dir_name, "particles.md"),
         "Matrix and Vector Types" => joinpath(tutorial_output_dir_name, "vectors.md"),
+        "Physical Constants" => joinpath(tutorial_output_dir_name, "constants.md"),
     ],
     "API reference" => [
         "Contents" => "library/outline.md",
         "Particles" => "library/particles.md",
+        "Constants" => "library/constants.md",
         "Coordinates" => "library/coordinates.md",
         "Phase Space Layout" => "library/phase_space_layout.md",
         "Phase Space Points" => "library/phasespacepoint.md",

--- a/docs/src/library/constants.md
+++ b/docs/src/library/constants.md
@@ -1,0 +1,14 @@
+# Physical Constants
+
+```@meta
+CurrentModule = QEDcore
+```
+
+```@docs
+ALPHA
+ALPHA_SQUARE
+ELEMENTARY_CHARGE
+ELEMENTARY_CHARGE_SQUARE
+ELECTRONMASS
+ONE_OVER_FOURPI
+```

--- a/docs/src/tutorial/constants.jl
+++ b/docs/src/tutorial/constants.jl
@@ -1,0 +1,60 @@
+using InteractiveUtils #hide
+using QEDcore # hide
+# # Using Physical Constants in a Type-Stable Way
+
+# This tutorial shows how to work with physical constants defined using `Base.@irrational`
+# in a way that is **type-stable**, **efficient**, and **compile-time safe**.
+
+# In `QEDcore.jl` the following constants are defined:
+
+# ```julia
+# ALPHA
+# ALPHA_SQUARE
+# ELEMENTARY_CHARGE
+# ELEMENTARY_CHARGE_SQUARE
+# ELECTRONMASS
+# ONE_OVER_FOURPI
+# ```
+
+# These constants are defined with the exact value given by [CODATA2022](@cite), but can be used in
+# any floating-point type (`Float64`, `Float32`, `Float16`) **without losing type stability**.
+
+# ## Convert to a Different Floating-Point Type
+
+# Use the target type constructor, like `Float32(ALPHA)`:
+
+Float32(ALPHA)
+
+#
+
+Float16(ELEMENTARY_CHARGE)
+
+# You can do this with any constant. The result is a value of the requested type, and the
+# conversion happens **statically at compile time**.
+
+# ## Automatic Conversion Using `one(T)` Pattern
+
+# This trick is useful for writing generic functions:
+
+T = Float32
+one(T) * ALPHA
+
+# ## Why This is Great: Compile-Time Efficiency
+
+# These conversions are evaluated at **compile time**. That means:
+
+# - The compiler inserts the constant value directly in machine code.
+# - There’s no runtime overhead.
+# - Your numerical code remains **type-stable** and **fast**.
+
+# You can verify this using:
+
+@code_typed Float32(ALPHA)
+
+# You'll see the compiler inserts a literal `Float32` like `0.007297353f0`.
+
+# ## Summary
+
+# - Use `Float32(ALPHA)` or `one(Float32)*ALPHA` to get type-stable values.
+# - All conversions happen at **compile time** — no performance hit.
+# - Great for writing generic numerical code with physical constants.

--- a/docs/src/tutorial/constants.jl
+++ b/docs/src/tutorial/constants.jl
@@ -1,11 +1,10 @@
-using InteractiveUtils #hide
-using QEDcore # hide
 # # Using Physical Constants in a Type-Stable Way
 
-# This tutorial shows how to work with physical constants defined using `Base.@irrational`
-# in a way that is **type-stable**, **efficient**, and **compile-time safe**.
+# This tutorial demonstrates how to work with physical constants defined using `Base.@irrational`
+# in a **type-preserving** way, i.e., ensuring that calculations don't accidentally upcast to a
+# different floating-point type due to the constant's default type.
 
-# In `QEDcore.jl` the following constants are defined:
+# In `QEDcore.jl`, the following constants are defined:
 
 # ```julia
 # ALPHA
@@ -16,45 +15,36 @@ using QEDcore # hide
 # ONE_OVER_FOURPI
 # ```
 
-# These constants are defined with the exact value given by [CODATA2022](@cite), but can be used in
-# any floating-point type (`Float64`, `Float32`, `Float16`) **without losing type stability**.
+# These constants are defined with the exact values given by [CODATA2022](@cite), and they can be
+# used with any floating-point type (`Float64`, `Float32`, `Float16`) **without requiring runtime conversion**.
 
-# ## Convert to a Different Floating-Point Type
+using InteractiveUtils #hide
+using QEDcore #hide
 
-# Use the target type constructor, like `Float32(ALPHA)`:
+# ## Converting to a Different Floating-Point Type
+
+# You can explicitly convert a constant to a target type using a constructor, like:
 
 Float32(ALPHA)
 
-#
+# or:
 
 Float16(ELEMENTARY_CHARGE)
 
-# You can do this with any constant. The result is a value of the requested type, and the
-# conversion happens **statically at compile time**.
-
-# ## Automatic Conversion Using `one(T)` Pattern
-
-# This trick is useful for writing generic functions:
-
-T = Float32
-one(T) * ALPHA
-
-# ## Why This is Great: Compile-Time Efficiency
-
-# These conversions are evaluated at **compile time**. That means:
-
-# - The compiler inserts the constant value directly in machine code.
-# - There’s no runtime overhead.
-# - Your numerical code remains **type-stable** and **fast**.
-
-# You can verify this using:
+# This works with any of the constants. The result is a value of the requested type,
+# and the conversion occurs **at compile time**:
 
 @code_typed Float32(ALPHA)
 
-# You'll see the compiler inserts a literal `Float32` like `0.007297353f0`.
+# This adds no runtime overhead.
 
-# ## Summary
+# ## Automatic Conversion during Arithmetic Operations
 
-# - Use `Float32(ALPHA)` or `one(Float32)*ALPHA` to get type-stable values.
-# - All conversions happen at **compile time** — no performance hit.
-# - Great for writing generic numerical code with physical constants.
+# For `Base.AbstractIrrational` types, arithmetic operations are defined such that
+# the result adopts the type of the other operand. For example:
+
+typeof(1.0 * ALPHA)
+
+#
+
+typeof(1.0f0 * ALPHA)

--- a/src/QEDcore.jl
+++ b/src/QEDcore.jl
@@ -1,5 +1,13 @@
 module QEDcore
 
+# constants
+export ALPHA,
+    ALPHA_SQUARE,
+    ELEMENTARY_CHARGE,
+    ELEMENTARY_CHARGE_SQUARE,
+    ELECTRONMASS,
+    ONE_OVER_FOURPI
+
 # lorentz vectors
 export SLorentzVector
 
@@ -50,6 +58,7 @@ export spin, polarization, momenta, getindex
 # TODO: move this to QEDbase
 export AbstractPerturbativeModel
 
+
 using Reexport
 using DocStringExtensions
 using StaticArrays
@@ -59,6 +68,7 @@ using LinearAlgebra
 @reexport using QEDbase
 
 include("math_helpers.jl")
+include("constants.jl")
 
 include("algebraic_objects/dirac_tensors/types.jl")
 include("algebraic_objects/dirac_tensors/multiplication.jl")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,0 +1,10 @@
+# source: CODATA 2022
+const _alpha_f64 = 7.2973525643e-3
+const _me_f64 = 5.1099895069e5
+
+Base.@irrational ALPHA big(_alpha_f64)
+Base.@irrational ALPHA_SQUARE big((_alpha_f64)^2)
+Base.@irrational ELEMENTARY_CHARGE big(sqrt(4 * pi * _alpha_f64))
+Base.@irrational ELEMENTARY_CHARGE_SQUARE big(4 * pi * _alpha_f64)
+Base.@irrational ELECTRONMASS big(_me_f64) # eV
+Base.@irrational ONE_OVER_FOURPI big(inv(4 * pi))

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,10 +1,65 @@
-# source: CODATA 2022
+# source: CODATA2022
 const _alpha_f64 = 7.2973525643e-3
 const _me_f64 = 5.1099895069e5
 
+"""
+    ALPHA
+
+The fine-structure constant ``\\alpha \\approx 1/137`` (dimensionless), which characterizes the strength of electromagnetic interactions.
+
+This value is defined using exactly the recommended value given in [CODATA2022](@cite), but can be safely converted to any floating-point type (e.g., `Float64(ALPHA)` or `one(Float32)*ALPHA`) in a type-stable and compile-time safe manner.
+"""
+ALPHA
 Base.@irrational ALPHA big(_alpha_f64)
+
+"""
+    ALPHA_SQUARE
+
+The square of the fine-structure constant, i.e. ``\\alpha^2``. Useful in second-order electromagnetic processes.
+
+Supports type-stable conversion to all standard floating-point types.
+"""
+ALPHA_SQUARE
 Base.@irrational ALPHA_SQUARE big((_alpha_f64)^2)
+
+"""
+    ELEMENTARY_CHARGE
+
+The elementary charge ``e`` in natural units, defined as ``\\sqrt{4\\pi \\alpha}``.
+
+Dimensionless in natural units; useful in calculating Coulomb interactions or electromagnetic coupling factors.
+
+This value is defined using exactly the recommended value given in [CODATA2022](@cite), but can be safely converted to any floating-point type (e.g., `Float64(ELEMENTARY_CHARGE)` or `one(Float32)*ELEMENTARY_CHARGE`) in a type-stable and compile-time safe manner.
+"""
+ELEMENTARY_CHARGE
 Base.@irrational ELEMENTARY_CHARGE big(sqrt(4 * pi * _alpha_f64))
+
+"""
+    ELEMENTARY_CHARGE_SQUARE
+
+The square of the elementary charge in natural units: ``e^2``.
+
+Commonly appears as a prefactor in scattering cross sections and Coulomb potentials.
+"""
+ELEMENTARY_CHARGE_SQUARE
 Base.@irrational ELEMENTARY_CHARGE_SQUARE big(4 * pi * _alpha_f64)
+
+"""
+    ELECTRONMASS
+
+Electron rest mass in **electronvolts** (eV), consistent with natural units.
+
+This value is defined using exactly the recommended value given in [CODATA2022](@cite), but can be safely converted to any floating-point type (e.g., `Float64(ELECTRONMASS)` or `one(Float32)*ELECTRONMASS`) in a type-stable and compile-time safe manner.
+"""
+ELECTRONMASS
 Base.@irrational ELECTRONMASS big(_me_f64) # eV
+
+"""
+    ONE_OVER_FOURPI
+
+The value ``1 / (4\\pi)``, often used as a Coulomb prefactor in Gaussian or natural unit systems.
+
+Convertible at compile time to all standard float types.
+"""
+ONE_OVER_FOURPI
 Base.@irrational ONE_OVER_FOURPI big(inv(4 * pi))

--- a/test/constants.jl
+++ b/test/constants.jl
@@ -1,0 +1,31 @@
+using QEDcore
+
+CONSTANTS = (
+    ALPHA,
+    ALPHA_SQUARE,
+    ELEMENTARY_CHARGE,
+    ELEMENTARY_CHARGE_SQUARE,
+    ELECTRONMASS,
+    ONE_OVER_FOURPI,
+)
+
+TYPES = (Float16, Float32, Float64)
+
+@testset "type check" begin
+    @testset "$C" for C in CONSTANTS
+
+        def_val = big(C)
+        @testset "$T" for T in TYPES
+            typed_val = T(def_val)
+            @test T(C) == typed_val
+            @test one(T) * C == typed_val
+        end
+    end
+end
+
+@testset "sanity checks" begin
+    @test isapprox(ELEMENTARY_CHARGE_SQUARE, ELEMENTARY_CHARGE^2)
+    @test isapprox(ALPHA_SQUARE, ALPHA^2)
+    @test isapprox(ONE_OVER_FOURPI, inv(4 * pi))
+    @test isapprox(ELEMENTARY_CHARGE_SQUARE * ONE_OVER_FOURPI, ALPHA)
+end

--- a/test/constants.jl
+++ b/test/constants.jl
@@ -19,6 +19,7 @@ TYPES = (Float16, Float32, Float64)
             typed_val = T(def_val)
             @test T(C) == typed_val
             @test one(T) * C == typed_val
+            @test T(T(C)) = T(C)
         end
     end
 end

--- a/test/constants.jl
+++ b/test/constants.jl
@@ -19,7 +19,7 @@ TYPES = (Float16, Float32, Float64)
             typed_val = T(def_val)
             @test T(C) == typed_val
             @test one(T) * C == typed_val
-            @test T(T(C)) = T(C)
+            @test T(T(C)) == T(C)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,9 @@ if cpu_tests
     @time @safetestset "phase spaces" begin
         include("phase_spaces.jl")
     end
-
+    @time @safetestset "constants" begin
+        include("constants.jl")
+    end
     # algebraic objects
     @time @safetestset "four momentum" begin
         include("algebraic_objects/four_momentum.jl")


### PR DESCRIPTION
## Add Physical Constants

This PR introduces a set of fundamental physical constants used in `QuantumElectrodynamcis.jl`. These constants are defined using `Base.@irrational` to ensure:

* **High precision by default**
* **Type-stable usage**
* **Compile-time conversion** for `Float64`, `Float32`, `Float16`, etc.

### Added Constants

Defined in `src/constants.jl`:

* `ALPHA` 
* `ALPHA_SQUARE` 
* `ELEMENTARY_CHARGE`
* `ELEMENTARY_CHARGE_SQUARE` 
* `ELECTRONMASS` 
* `ONE_OVER_FOURPI`

Each constant includes a Julia docstring describing its physical meaning and intended use in natural units.

### Added Unit Tests

New test file: `test/constants.jl`

Covers:

* Correct type-stable conversion to `Float64`, `Float32`, `Float16`
* Numerical sanity checks
* Round-trip type safety (e.g., `Float32(ALPHA)` stays `Float32`)

### Added Literate.jl Tutorial

New tutorial: `tutorials/constants_tutorial.jl`

* Demonstrates usage of all constants
* Shows both explicit casting (`Float32(ALPHA)`) and `one(T)*constant` pattern
* Highlights compile-time safety

## Summary

This PR improves the usability and robustness of physical constants within `QuantumElectrodynamics.jl`. It ensures they are:

* Easy to use in generic code
* Efficient due to compile-time conversion
* Well-documented and tested