### PR TITLE
Math helper precision improvement

### DIFF
--- a/src/math_helpers.jl
+++ b/src/math_helpers.jl
@@ -50,5 +50,5 @@ Calculate `sqrt(x^2 - y^2)` with more precision than default when x ≈ y.
 """
 function sq_diff_sqrt(x::T1, y::T2) where {T1, T2}
     T = promote_type(T1, T2)
-    return sqrt(T(x) + T(y)) * sqrt(T(x) - T(y))
+    return sqrt((T(x) + T(y)) * (T(x) - T(y)))
 end


### PR DESCRIPTION
Using only one square root instead of two removes some small imprecision reported in #120 