### PR TITLE
adds electron-photon Heads-on psl

### DIFF
--- a/src/QEDcore.jl
+++ b/src/QEDcore.jl
@@ -43,6 +43,7 @@ export coordinate_name, particle_index
 export AbstractTwoBodyInPhaseSpaceLayout
 export AbstractTwoBodyRestSystem, TwoBodyRestSystem, TwoBodyTargetSystem, TwoBodyBeamSystem
 export FlatPhaseSpaceLayout
+export PhotonElectronHeadsOnSystem, XAxis, YAxis, ZAxis
 
 # coordinate maps
 export CoordinateMap
@@ -89,6 +90,7 @@ include("coordinate_map/cached.jl")
 include("phase_space_layouts/in_channel/two_body/utils.jl")
 include("phase_space_layouts/in_channel/two_body/general.jl")
 include("phase_space_layouts/in_channel/two_body/rest_system.jl")
+include("phase_space_layouts/in_channel/two_body/heads_on.jl")
 
 include("phase_space_layouts/out_channel/flat_phase_space.jl")
 

--- a/src/phase_space_layouts/in_channel/two_body/heads_on.jl
+++ b/src/phase_space_layouts/in_channel/two_body/heads_on.jl
@@ -1,0 +1,47 @@
+"""
+
+    AbstractAxis
+
+Abstract base type to describe the axis of a vector, e.g. the k-vector of a photon. Mostly used for multiple dispatch.
+"""
+abstract type AbstractAxis end
+abstract type AbstractDefiniteAxis <: AbstractAxis end
+abstract type AbstractIndefiniteAxis <: AbstractAxis end
+
+struct XAxis <: AbstractDefiniteAxis end
+struct YAxis <: AbstractDefiniteAxis end
+struct ZAxis <: AbstractDefiniteAxis end
+
+abstract type AbstractTwoBodyHeadsOnSystem <: AbstractTwoBodyInPhaseSpaceLayout end
+QEDbase.phase_space_dimension(proc, model, ::AbstractTwoBodyHeadsOnSystem) = 2 # E, omega
+
+"""
+    PhotonElectronHeadsOnSystem([dir::AbstractDefiniteAxis])
+
+Define a head-on collision system between a photon and an electron,
+where both particles propagate along the given definite axis `dir`
+(defaults to the `ZAxis`).
+"""
+struct PhotonElectronHeadsOnSystem{D <: AbstractDefiniteAxis} <: AbstractTwoBodyHeadsOnSystem
+    dir::D
+end
+QEDbase.particle_direction(psl::PhotonElectronHeadsOnSystem) = psl.dir
+PhotonElectronHeadsOnSystem() = PhotonElectronHeadsOnSystem(ZAxis())
+
+#Base.broadcastable(psl::PhotonElectronHeadsOnSystem) = Ref(psl)
+
+@inline _build_directed_moms(dir::XAxis, E, rho, om) = (SFourMomentum(E, -rho, 0, 0), SFourMomentum(om, om, 0, 0))
+@inline _build_directed_moms(dir::YAxis, E, rho, om) = (SFourMomentum(E, 0, -rho, 0), SFourMomentum(om, 0, om, 0))
+@inline _build_directed_moms(dir::ZAxis, E, rho, om) = (SFourMomentum(E, 0, 0, -rho), SFourMomentum(om, 0, 0, om))
+
+function QEDbase._build_momenta(
+        ::AbstractProcessDefinition,
+        ::AbstractPerturbativeModel,
+        psl::PhotonElectronHeadsOnSystem,
+        in_coords::NTuple{2, T}
+    ) where {T <: Real}
+    E, om = in_coords
+    rho = sqrt(E^2 - one(E))
+
+    return _build_directed_moms(particle_direction(psl), E, rho, om)
+end

--- a/test/phase_space_layouts/in_channel/two_body/heads_on.jl
+++ b/test/phase_space_layouts/in_channel/two_body/heads_on.jl
@@ -1,0 +1,39 @@
+using Random
+using QEDcore
+
+RNG = MersenneTwister(137137)
+ATOL = 0.0
+RTOL = sqrt(eps())
+
+include("../../../test_implementation/TestImplementation.jl")
+
+TESTMODEL = TestImplementation.TestPerturbativeModel()
+
+INPARTICLES = (Electron(), Photon())
+
+N_OUTGOING = 2
+OUTPARTICLE = Tuple(rand(TestImplementation.PARTICLE_SET, N_OUTGOING))
+
+TEST_AXES = (XAxis(), YAxis(), ZAxis())
+
+TESTPROC = TestImplementation.TestProcess(INPARTICLES, OUTPARTICLE)
+
+ENERGIES = 1.0 .+ (rand(RNG), 10 * rand(RNG), 100 * rand(RNG))
+OMEGAS = (1.0e-6 * rand(RNG), 1.0e3 * rand(RNG), rand(RNG), 1.0e3 * rand(RNG), 1.0e6 * rand(RNG))
+
+
+@testset "$AXIS" for AXIS in TEST_AXES
+    PSL = PhotonElectronHeadsOnSystem(AXIS)
+    coord_map = CoordinateMap(TESTPROC, TESTMODEL, PSL)
+    @testset "E = $E, omega = $omega" for (E, omega) in Iterators.product(ENERGIES, OMEGAS)
+
+
+        P, K = coord_map((E, omega))
+
+        @test isapprox(getMass(P), 1.0)
+        @test isapprox(getMass(K), 0.0)
+        @test isapprox(getE(P), E)
+        @test isapprox(getE(K), omega)
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,10 @@ if cpu_tests
         include("phase_space_layouts/in_channel/two_body/rest_system.jl")
     end
 
+    @time @safetestset "two body heads-on system" begin
+        include("phase_space_layouts/in_channel/two_body/heads_on.jl")
+    end
+
     @time @safetestset "flat phase space layout" begin
         include("phase_space_layouts/out_channel/flat_phase_space.jl")
     end


### PR DESCRIPTION
Adds `PhotonElectronHeadsOnSystem`, a phase space layout in which the electron and photon counter-propagate along a single axis.